### PR TITLE
Fixed black screen on iOS 11/Safari 11

### DIFF
--- a/src/components/QrcodeReader.vue
+++ b/src/components/QrcodeReader.vue
@@ -141,6 +141,8 @@ export default {
         } else {
           video.src = this.stream
         }
+        video.playsInline = true
+        video.play()
       } catch (e) {
         // NotAllowedError, NotSupportedError, NotFoundError
         this.initReject(e)


### PR DESCRIPTION
Changelog:
* Added playsInline and play() to the video stream so it works with the WebRTC Safari implementation.

Notes:
* The camera will only work inside Safari. If you add the webapp to your homescreen the camera will not work and you won't get any error, the same is true for chrome, firefox or a webview inside an app since there is no WebRTC in its WebKit implementation yet.
* I was able to get it running on an android tablet with Chrome running on a KitKat 4.4 after adding the lines. But sometimes the browser just ignores and never prompt to allow the camera again or throw any error, only a reboot it was working again (maybe google's implementation of WebRTC is still buggy?). I wasn't able to test on an Android phone yet.
