### PR TITLE
Add video attributes to always allow iOS playback

### DIFF
--- a/src/components/QrcodeReader.vue
+++ b/src/components/QrcodeReader.vue
@@ -26,6 +26,9 @@
         ref="video"
         v-show="shouldScan"
         class="qrcode-reader__camera"
+        autoplay
+        muted
+        playsinline
       ></video>
     </div>
   </div>

--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -40,9 +40,6 @@ export default async function (constraints, videoEl) {
     videoEl.src = stream
   }
 
-  videoEl.playsInline = true
-  videoEl.play() // firefox does not emit `loadeddata` if video not playing
-
   await streamLoaded
 
   return new Camera(videoEl, stream)


### PR DESCRIPTION
Hey, thanks for the great component! Very happy with it so far. Except when using low power mode in ios.

It seems that video elements aren't allowed to play without user interaction to enable it. With these attributes the stream is set to autoplay, be muted and also to display inline just to make certain that it won't accidentally pop up full screen.

Reference:
https://webkit.org/blog/6784/new-video-policies-for-ios/

I can't say for certain what side effects this will have because I have only tested it with my devices. But for Firefox and safari on Mac OS Mojave and iPhone 8 running ios 12 the behavior is unchanged. Except of course that there is a working scan and video stream when using the latter on low power mode. 