### PR TITLE
Split qrcode-reader in 3 different components

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@
   <a href="https://github.com/Naereen/badges">
     <img src="https://img.shields.io/badge/badges-awesome-green.svg" alt="badges = awesome">
   </a>
+
+  <br>
+
+  <a href="https://bundlephobia.com/result?p=vue-qrcode-reader">
+    <img src="https://badgen.net/bundlephobia/minzip/vue-qrcode-reader" alt="size minified + gzipped">
+  </a>
 </p>
 
 A set of Vue.js components, allowing you to detect and decode QR codes, without leaving the browser.

--- a/README.md
+++ b/README.md
@@ -31,13 +31,28 @@
   </a>
 </p>
 
-A Vue.js 2 component, accessing the device camera and allowing users to read QR codes, within the browser.
+A set of Vue.js components, allowing you to detect and decode QR codes, without leaving the browser.
 
-* read camera stream and/or drag-and-dropped images
-* customizable visual tracking of QR codes
-* responsive and layout agnostic
+* `QrcodeStream` accesses the device camera and continuously scans the incoming frames.
+* `QrcodeDropZone` renders to an empty region where you can drag-and-drop images to be decoded.
+* `QrcodeCapture` is a classic file upload field, instantly scanning all files you select.
 
-### [Demos](https://gruhn.github.io/vue-qrcode-reader/)
+All components are responsive. What doesn't fit your layout can be customized.
+
+You also get simple elegant APIs:
+
+```html
+<qrcode-stream @decode="onDecode"></qrcode-stream>
+```
+```js
+methods: {
+  onDecode (decodedString) {
+    // ...
+  }
+}
+```
+
+### [Demos](https://gruhn.github.io/vue-qrcode-reader/) | [Docu](https://github.com/gruhn/vue-qrcode-reader/wiki)
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/screenshot1.png" height="500" alt="Screenshot 1">
@@ -47,6 +62,10 @@ A Vue.js 2 component, accessing the device camera and allowing users to read QR 
 
 # Browser support
 
+#### `QrcodeStream`
+
+This component fundamentally depends on the [Stream API](https://caniuse.com/#feat=stream).
+
 | ![Internet Explorer](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/ie_32x32.png) | ![Edge](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/edge_32x32.png) | ![Firefox](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/firefox_32x32.png) | ![Chrome](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/chrome_32x32.png) | ![Safari](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/safari_32x32.png) |
 |:--:|:---:|:---:|:---:|:---:|
 | No | Yes | Yes | Yes | 11+ |
@@ -54,260 +73,54 @@ A Vue.js 2 component, accessing the device camera and allowing users to read QR 
 * Chrome requires [HTTPS or localhost](https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins) (see [#38](../../issues/38) for help)
 * Safari also requires HTTPS **even** on localhost (see [#48](../../issues/48))
 * on iOS it **only** works with Safari. Chrome or Firefox for iOS are not supported (see [#29](../../issues/29))
-* more details on [Caniuse](https://caniuse.com/#feat=stream)
 
-# API
+#### `QrcodeDropZone` and `QrcodeCapture`
 
-| Prop      | Valid Types           | Default                   |
-|-----------|-----------------------|---------------------------|
-| `:track`  | `Boolean`, `Function` | `true`                    |
-| `:paused` | `Boolean`             | `false`                   |
-| `:camera` | `Boolean`, `Object`   | see [Usage](#camera-prop) |
+The newest API these components depend on is the [FileReader API](https://caniuse.com/#feat=filereader).
 
-| Event     | Payload Type      |
-|-----------|-------------------|
-| `@decode` | `String`          |
-| `@detect` | `Promise<Object>` |
-| `@init`   | `Promise<void>`   |
+| ![Internet Explorer](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/ie_32x32.png) | ![Edge](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/edge_32x32.png) | ![Firefox](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/firefox_32x32.png) | ![Chrome](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/chrome_32x32.png) | ![Safari](https://raw.githubusercontent.com/gruhn/vue-qrcode-reader/master/.github/safari_32x32.png) |
+|:--:|:---:|:---:|:---:|:---:|
+| 10+ | Yes | Yes | Yes | Yes |
 
-# Usage
-
-### `decode` event
-Once a stream from the users camera is loaded, it is displayed and continuously scanned for QR codes. Results are indicated by the `decode` event. This also accounts for decoded images drag-and-dropped in the area the component occupies.
-
-```html
-<qrcode-reader @decode="onDecode"></qrcode-reader>
-```
-```javascript
-methods: {
-  onDecode (decodedString) {
-    // ...
-  }
-}
-```
-
-> You might notice that when you scan the same QR code multiple times in a row, `decode` is still only emitted once. When you hold a QR code in the camera, frames are actually decoded multiple times a second but you don't want to be flooded with `decode` events that often. That's why the last decoded QR code is always cached and only new results are propagated. However, you can clear this internal cache by setting the `paused` prop to true.
-
-### `detect` event
-The `detect` event is quite similar to `decode` but it provides more details. `decode` only gives you the string encoded by QR codes. `detect` additionally
-
-* tells you where results came from (i.e. a camera stream, a drag-and-dropped file or url)
-* gives you the unprocessed raw image data
-* the coordinates of the QR code in the image/camera frame
-
-In case of errors `decode` also silently fails. For example when a non-image file is drag-and-dropped.
-
-```html
-<qrcode-reader @detect="onDetect"></qrcode-reader>
-```
-```javascript
-methods: {
-  async onDetect (promise) {
-    try {
-      const {
-        source,       // 'file', 'url' or 'stream'
-        imageData,    // raw image data of image/frame
-        content,      // decoded String
-        location      // QR code coordinates
-      } = await promise
-
-      // ...
-    } catch (error) {
-      if (error.name === 'DropImageFetchError') {
-        // drag-and-dropped URL (probably just an <img> element) from different
-        // domain without CORS header caused same-origin-policy violation
-      } else if (error.name === 'DropImageDecodeError') {
-        // drag-and-dropped file is not of type image and can't be decoded
-      } else {
-        // idk, open an issue ¯\_(ツ)_/¯
-      }
-    }
-  }
-}
-```
-
-### `init` event
-It might take a while before the component is ready and the scanning process starts. The user has to be asked for camera access permission first and the camera stream has to be loaded.
-
-If you want to show a loading indicator, you can listen for the `init` event. It's emitted as soon as the component is mounted and carries a promise which resolves when everything is ready. The promise is rejected if initialization fails. This can have [a couple of reasons](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Exceptions).
-
-> In Chrome you can't prompt users for permissions a second time. Once denied, users can only manually grant them. Make sure your users understand why you need access to their camera **before** you mount this component. Otherwise they might panic and deny and then get frustrated because they don't know how to change their decision.
-
-```html
-<qrcode-reader @init="onInit"></qrcode-reader>
-```
-```javascript
-methods: {
-  async onInit (promise) {
-    // show loading indicator
-
-    try {
-      await promise
-
-      // successfully initialized
-    } catch (error) {
-      if (error.name === 'NotAllowedError') {
-        // user denied camera access permisson
-      } else if (error.name === 'NotFoundError') {
-        // no suitable camera device installed
-      } else if (error.name === 'NotSupportedError') {
-        // page is not served over HTTPS (or localhost)
-      } else if (error.name === 'NotReadableError') {
-        // maybe camera is already in use
-      } else if (error.name === 'OverconstrainedError') {
-        // passed constraints don't match any camera.
-        // Did you requested the front camera although there is none?
-      } else {
-        // browser might be lacking features (WebRTC, ...)
-      }
-    } finally {
-      // hide loading indicator
-    }
-  }
-}
-```
-### `track` prop
-
-By default detected QR codes are visually highlighted. A transparent canvas overlays the camera stream. When a QR code is detected, its location is painted to the canvas. You can enable/disable this feature by passing `true`/`false` via the `track` prop. If tracking is disabled the camera stream is scanned much less frequently. So if you encounter performance problems on your target device, this might help.
-
-You can also pass a function with `track` to customize the way the location is painted. This function is called to produce each frame. It receives the location object as the first argument and a `CanvasRenderingContext2D` instance as the second argument.
-
-> Avoid access to reactive properties in this function (like stuff in `data`, `computed` or your Vuex store). The function is called several times a second and might cause memory leaks. If you want to be safe don't access `this` at all.
-
-Say you want to paint in a different color that better fits your overall page theme.
-
-```html
-<qrcode-reader :track="repaintLocation"></qrcode-reader>
-```
-```javascript
-methods: {
-  repaintLocation (location, ctx) {
-    const {
-      topLeftCorner,
-      topRightCorner,
-      bottomLeftCorner,
-      bottomRightCorner,
-      // topLeftFinderPattern,
-      // topRightFinderPattern,
-      // bottomLeftFinderPattern
-    } = location
-
-    ctx.strokeStyle = 'blue' // instead of red
-
-    ctx.beginPath()
-    ctx.moveTo(topLeftCorner.x, topLeftCorner.y)
-    ctx.lineTo(bottomLeftCorner.x, bottomLeftCorner.y)
-    ctx.lineTo(bottomRightCorner.x, bottomRightCorner.y)
-    ctx.lineTo(topRightCorner.x, topRightCorner.y)
-    ctx.lineTo(topLeftCorner.x, topLeftCorner.y)
-    ctx.closePath()
-
-    ctx.stroke()
-  }
-}
-```
-
-### default slot
-
-Distributed content will overlay the camera stream, wrapped in a `position: absolute` container.
-
-```html
-<qrcode-reader>
-  <b>stuff here overlays the camera stream</b>
-</qrcode-reader>
-```
-
-### `paused` prop
-
-With the `paused` prop you can prevent further `decode` propagation. Functions passed via `track` are also stopped being called. Useful for example if you want to validate results one at a time.
-
-> When the component is paused the camera stream freezes but is actually still running in the background. The browser will tell you that the camera is still in use. If you want to kill the stream completely you can pass `false` to the `camera` prop.
-
-```html
-<qrcode-reader @decode="onDecode" :paused="paused"></qrcode-reader>
-```
-```javascript
-data () {
-  return {
-    paused: false
-  }
-},
-
-methods: {
-  onDecode (content) {
-    this.paused = true
-    // ...
-  }
-}
-```
-
-### `camera` prop
-
-With the `camera` prop you can filter the set of cameras installed on a client device. For example, if you want to access the front camera instead of the rear camera, pass this:
-
-```html
-<qrcode-reader :camera="{ facingMode: 'user' }"></qrcode-reader>
-```
-
-This component uses [getUserMedia](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) to request camera streams. This method accepts [a constraints object](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_video_tracks). By default this component passes this:
-
-```javascript
-{
-  audio: false, // don't request microphone access
-  video: {
-    facingMode: { ideal: 'environment' }, // use rear camera if available
-    width: { min: 360, ideal: 680, max: 1920 }, // constrain video width resolution
-    height: { min: 240, ideal: 480, max: 1080 }, // constrain video height resolution
-  }
-}
-```
-
-This `video` part in this object is essentially what you can change using the `camera` prop. Note that you only have to pass properties you want to override. All the other default properties on the first depth level are preserved. Here are a few examples:
-
-`camera="{ facingMode: 'user' }"`: the `facingMode` property is passed and is the only property that changes. `width` and `height` are still the default value.
-
-`camera="false"`: overrides ALL default properties. No camera can match those constraints so no camera is request in the first place. You can use this to turn of the camera at runtime.
-
-`camera="{}"`: since an empty object does not contain properties that could override something, this is just like falling back to the default. The same as not using the `camera` prop at all or passing `undefined`/`null`.
-
-`camera="true"`: overrides ALL default properties. You will accept any camera type there is. Not recommended though as iOS seems to have trouble when the `height` and `width` constraints are missing.
-
-> If you change this property after initialization, a new camera stream has to be requested and the `init` event will be emitted again.
-
+* Drag-and-drop is not supported on mobile
 
 # Installation
 
 ```bash
-yarn add vue-qrcode-reader
+npm install --save vue-qrcode-reader
 ```
-or using NPM:
+or with Yarn:
 
 ```bash
-npm install --save vue-qrcode-reader
+yarn add vue-qrcode-reader
 ```
 
 ## Default import
 
-Register component globally:
+You can either import the components independantly and register them in another
+components scope:
+
+```javascript
+import { QrcodeStream, QrcodeDropZone, QrcodeCapture } from 'vue-qrcode-reader'
+
+Vue.component('my-component', {
+  components: {
+    QrcodeStream,
+    QrcodeDropZone,
+    QrcodeCapture
+  },
+
+  // ...
+))
+```
+
+Or alternatively register all of them globally right away:
 
 ```javascript
 import Vue from 'vue'
 import VueQrcodeReader from 'vue-qrcode-reader'
 
 Vue.use(VueQrcodeReader)
-```
-
-Register locally in other components scope:
-
-```javascript
-import Vue from 'vue'
-import { QrcodeReader } from 'vue-qrcode-reader'
-
-Vue.component('my-component', {
-  components: { QrcodeReader },
-
-  // ...
-)
 ```
 
 **⚠️ A css file is included when importing the package. You may have to setup your bundler to embed the css in your page.**
@@ -320,23 +133,24 @@ Besides Vue you need to include the following CSS and JS file:
  * `<link href="`[vue-qrcode-reader.css](https://unpkg.com/vue-qrcode-reader/dist/vue-qrcode-reader.css)`"  rel="stylesheet">`
  * `<script src="`[vue-qrcode-reader.browser.js](https://unpkg.com/vue-qrcode-reader/dist/vue-qrcode-reader.browser.js)`"></script>`
 
-The plugin should be auto-installed. If not, you can install it manually.
+The global variable `window.VueQrcodeReader` should now be available.
 
-Register component globally:
+All components should be automatically registered globally. If not, you can do it like this:
 
 ```javascript
 Vue.use(VueQrcodeReader)
 ```
 
-Register locally in other components scope:
+You can also register specific components locally, in one of your components:
 
 ```javascript
 Vue.component('my-component', {
   components: {
-    'qrcode-reader': VueQrcodeReader.QrcodeReader
+    'qrcode-stream': VueQrcodeReader.QrcodeStream,
+    'qrcode-drop-zone': VueQrcodeReader.QrcodeDropZone,
+    'qrcode-capture': VueQrcodeReader.QrcodeCapture
   },
 
   // ...
 )
 ```
-

--- a/src/components/QrcodeCapture.vue
+++ b/src/components/QrcodeCapture.vue
@@ -1,0 +1,39 @@
+<template lang="html">
+  <input
+    @change="onChangeInput"
+    type="file"
+    name="image"
+    accept="image/*"
+    capture="environment"
+    multiple>
+</template>
+
+<script>
+import { scan } from '../misc/scanner.js'
+import { imageDataFromFile } from '../misc/image-data.js'
+import CommonAPI from '../mixins/CommonAPI.vue'
+
+export default {
+
+  mixins: [ CommonAPI ],
+
+  methods: {
+    onChangeInput (event) {
+      const files = [...event.target.files]
+      const resultPromises = files.map(this.processFile)
+
+      resultPromises.forEach(this.onDetect)
+
+      console.log(Promise.all(resultPromises))
+    },
+
+    async processFile (file) {
+      const imageData = await imageDataFromFile(file)
+      const scanResult = await scan(imageData)
+
+      return { source: 'file', ...scanResult }
+    },
+  },
+
+}
+</script>

--- a/src/components/QrcodeStream.vue
+++ b/src/components/QrcodeStream.vue
@@ -1,0 +1,338 @@
+<template lang="html">
+  <div class="qrcode-stream">
+    <div class="qrcode-stream__inner-wrapper">
+      <div
+        class="qrcode-stream__overlay">
+        <slot></slot>
+      </div>
+
+      <canvas
+        ref="trackingLayer"
+        class="qrcode-stream__tracking-layer"
+      ></canvas>
+
+      <canvas
+        ref="pauseFrame"
+        v-show="!shouldScan"
+        class="qrcode-stream__pause-frame"
+      ></canvas>
+
+      <video
+        ref="video"
+        v-show="shouldScan"
+        class="qrcode-stream__camera"
+        autoplay
+        muted
+        playsinline
+      ></video>
+    </div>
+  </div>
+</template>
+
+<script>
+import { keepScanning } from '../misc/scanner.js'
+import Camera from '../misc/camera.js'
+import isBoolean from 'lodash/isBoolean'
+import CommonAPI from '../mixins/CommonAPI.vue'
+
+export default {
+
+  mixins: [ CommonAPI ],
+
+  props: {
+    paused: {
+      type: Boolean,
+      default: false,
+    },
+
+    camera: {
+      type: [Object, Boolean],
+      default: () => ({}), // empty object
+    },
+
+    track: {
+      type: [Function, Boolean],
+      default: true,
+    },
+  },
+
+  data () {
+    return {
+      cameraInstance: null,
+      destroyed: false,
+    }
+  },
+
+  computed: {
+
+    shouldStream () {
+      return this.paused === false &&
+        this.destroyed === false &&
+        this.constraints.video !== false
+    },
+
+    shouldScan () {
+      return this.shouldStream === true &&
+        this.cameraInstance !== null
+    },
+
+    /**
+     * Minimum delay in milliseconds between frames to be scanned. Don't scan
+     * so often when visual tracking is disabled to improve performance.
+     */
+    scanInterval () {
+      if (this.track === false) {
+        return 500
+      } else {
+        return 40 // ~ 25fps
+      }
+    },
+
+    /**
+     * Full constraints object which is passed to `getUserMedia` to request a
+     * camera stream. Properties define if a certain camera is adequate or not.
+     */
+    constraints () {
+      if (isBoolean(this.camera)) {
+        return {
+          audio: false,
+          video: this.camera,
+        }
+      } else {
+        return {
+          audio: false,
+          video: {
+            facingMode: { ideal: 'environment' },
+            width: { min: 360, ideal: 640, max: 1920 },
+            height: { min: 240, ideal: 480, max: 1080 },
+
+            ...this.camera,
+          },
+        }
+      }
+    },
+
+    trackRepaintFunction () {
+      if (this.track === true) {
+        return function (location, ctx) {
+          const {
+            topLeftCorner,
+            topRightCorner,
+            bottomLeftCorner,
+            bottomRightCorner,
+          } = location
+
+          ctx.strokeStyle = 'red'
+
+          ctx.beginPath()
+          ctx.moveTo(topLeftCorner.x, topLeftCorner.y)
+          ctx.lineTo(bottomLeftCorner.x, bottomLeftCorner.y)
+          ctx.lineTo(bottomRightCorner.x, bottomRightCorner.y)
+          ctx.lineTo(topRightCorner.x, topRightCorner.y)
+          ctx.lineTo(topLeftCorner.x, topLeftCorner.y)
+          ctx.closePath()
+
+          ctx.stroke()
+        }
+      } else if (this.track === false) {
+        return null
+      } else {
+        return this.track
+      }
+    },
+
+  },
+
+  watch: {
+
+    shouldStream (shouldStream) {
+      if (!shouldStream) {
+        const frame = this.cameraInstance.captureFrame()
+        this.paintPauseFrame(frame)
+      }
+    },
+
+    shouldScan (shouldScan) {
+      if (shouldScan) {
+        this.clearPauseFrame()
+        this.clearTrackingLayer()
+        this.startScanning()
+      }
+    },
+
+    constraints: {
+      deep: true,
+
+      handler () {
+        this.$emit('init', this.init())
+      },
+    },
+  },
+
+  mounted () {
+    this.$emit('init', this.init())
+  },
+
+  beforeDestroy () {
+    this.beforeResetCamera()
+    this.destroyed = true
+  },
+
+  methods: {
+
+    async init () {
+      this.beforeResetCamera()
+
+      if (this.constraints.video === false) {
+        this.cameraInstance = null
+      } else {
+        this.cameraInstance = await Camera(this.constraints, this.$refs.video)
+      }
+    },
+
+    startScanning () {
+      const detectHandler = result => {
+        this.onDetect(
+          Promise.resolve({ source: 'stream', ...result })
+        )
+      }
+
+      keepScanning(this.cameraInstance, {
+        detectHandler,
+        locateHandler: this.onLocate,
+        shouldContinue: () => this.shouldScan,
+        minDelay: this.scanInterval,
+      })
+    },
+
+    beforeResetCamera () {
+      if (this.cameraInstance !== null) {
+        this.cameraInstance.stop()
+        this.cameraInstance = null
+      }
+    },
+
+    onLocate (location) {
+      if (this.trackRepaintFunction !== null) {
+        if (location === null) {
+          this.clearTrackingLayer()
+        } else {
+          this.repaintTrackingLayer(location)
+        }
+      }
+    },
+
+    /**
+     * The coordinates are based on the original camera resolution but the
+     * video element is responsive and scales with space available. Therefore
+     * the coordinates are re-calculated to be relative to the video element.
+     */
+    normalizeLocation (widthRatio, heightRatio, location) {
+      const normalized = {}
+
+      for (const key in location) {
+        normalized[key] = {
+          x: Math.floor(location[key].x * widthRatio),
+          y: Math.floor(location[key].y * heightRatio),
+        }
+      }
+
+      return normalized
+    },
+
+    repaintTrackingLayer (location) {
+      const video = this.$refs.video
+      const canvas = this.$refs.trackingLayer
+      const ctx = canvas.getContext('2d')
+
+      const displayWidth = video.offsetWidth
+      const displayHeight = video.offsetWidth
+      const resolutionWidth = video.videoWidth
+      const resolutionHeight = video.videoHeight
+
+      window.requestAnimationFrame(() => {
+        canvas.width = displayWidth
+        canvas.height = displayHeight
+
+        const widthRatio = displayWidth / resolutionWidth
+        const heightRatio = displayHeight / resolutionHeight
+
+        location = this.normalizeLocation(widthRatio, heightRatio, location)
+
+        this.trackRepaintFunction(location, ctx)
+      })
+    },
+
+    clearTrackingLayer () {
+      const canvas = this.$refs.trackingLayer
+      const ctx = canvas.getContext('2d')
+
+      window.requestAnimationFrame(() => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height)
+      })
+    },
+
+    paintPauseFrame (imageData) {
+      const canvas = this.$refs.pauseFrame
+      const ctx = canvas.getContext('2d')
+
+      window.requestAnimationFrame(() => {
+        canvas.width = imageData.width
+        canvas.height = imageData.height
+
+        ctx.putImageData(imageData, 0, 0)
+      })
+    },
+
+    clearPauseFrame () {
+      const canvas = this.$refs.pauseFrame
+      const ctx = canvas.getContext('2d')
+
+      window.requestAnimationFrame(() => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height)
+      })
+    },
+
+  },
+}
+</script>
+
+<style lang="css">
+.qrcode-stream {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.qrcode-stream__inner-wrapper {
+  position: relative;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.qrcode-stream__overlay,
+.qrcode-stream__tracking-layer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+}
+
+.qrcode-stream__camera,
+.qrcode-stream__pause-frame {
+  display: block;
+  object-fit: contain;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.qrcode-stream__overlay {
+  z-index: 30;
+}
+
+.qrcode-stream__tracking-layer {
+  z-index: 20;
+}
+</style>

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,19 @@
 import QrcodeReader from './components/QrcodeReader.vue'
 import QrcodeCapture from './components/QrcodeCapture.vue'
-// import QrcodeDropZone from './components/QrcodeDropZone.vue'
+import QrcodeDropZone from './components/QrcodeDropZone.vue'
 
 // Install the components
 export function install (Vue) {
   Vue.component('qrcode-reader', QrcodeReader)
   Vue.component('qrcode-capture', QrcodeCapture)
-  // Vue.component('qrcode-drop-zone', QrcodeDropZone)
+  Vue.component('qrcode-drop-zone', QrcodeDropZone)
 }
 
 // Expose the components
 export {
   QrcodeReader,
   QrcodeCapture,
-  // QrcodeDropZone,
+  QrcodeDropZone,
 }
 
 /* -- Plugin definition & Auto-install -- */

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,24 @@
+/* DEPRECATED: QrcodeReader renamed to QrcodeStream */
 import QrcodeReader from './components/QrcodeReader.vue'
+
+import QrcodeStream from './components/QrcodeStream.vue'
 import QrcodeCapture from './components/QrcodeCapture.vue'
 import QrcodeDropZone from './components/QrcodeDropZone.vue'
 
 // Install the components
 export function install (Vue) {
+  /* DEPRECATED: QrcodeReader renamed to QrcodeStream */
   Vue.component('qrcode-reader', QrcodeReader)
+
+  Vue.component('qrcode-stream', QrcodeStream)
   Vue.component('qrcode-capture', QrcodeCapture)
   Vue.component('qrcode-drop-zone', QrcodeDropZone)
 }
 
 // Expose the components
 export {
-  QrcodeReader,
+  QrcodeReader, /* DEPRECATED: QrcodeReader renamed to QrcodeStream */
+  QrcodeStream,
   QrcodeCapture,
   QrcodeDropZone,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,18 @@
 import QrcodeReader from './components/QrcodeReader.vue'
+import QrcodeCapture from './components/QrcodeCapture.vue'
 // import QrcodeDropZone from './components/QrcodeDropZone.vue'
 
 // Install the components
 export function install (Vue) {
   Vue.component('qrcode-reader', QrcodeReader)
+  Vue.component('qrcode-capture', QrcodeCapture)
+  // Vue.component('qrcode-drop-zone', QrcodeDropZone)
 }
 
 // Expose the components
 export {
   QrcodeReader,
+  QrcodeCapture,
   // QrcodeDropZone,
 }
 

--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -1,3 +1,4 @@
+import { StreamApiNotSupportedError } from './errors.js'
 import { imageDataFromVideo } from './image-data.js'
 import { hasFired } from './promisify.js'
 
@@ -22,7 +23,7 @@ class Camera {
 
 export default async function (constraints, videoEl) {
   if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) {
-    throw new Error('WebRTC API not supported in this browser')
+    throw new StreamApiNotSupportedError()
   }
 
   const stream = await navigator.mediaDevices.getUserMedia(constraints)

--- a/src/misc/errors.js
+++ b/src/misc/errors.js
@@ -14,3 +14,11 @@ export class DropImageDecodeError extends Error {
     this.name = 'DropImageDecodeError'
   }
 }
+
+export class StreamApiNotSupportedError extends Error {
+  constructor () {
+    super('this browser has no Stream API support')
+
+    this.name = 'StreamApiNotSupportedError'
+  }
+}


### PR DESCRIPTION
Introducing a dedicated component for classic file upload/media capture. 

Import independently from main component:

```js
import { QrcodeReader, QrcodeCapture } from 'vue-qrcode-reader'
```

The component emits `decode` and `detect` exactly like the main component:

```html
<qrcode-capture @decode="..." @detect="..." />
```
The component renders to a simple `input` element:

```html
<input
    type="file"
    name="image"
    accept="image/*"
    capture="environment"
    multiple>
```

