### PR TITLE
Fix for StreamApiNotSupportedError exception

### DIFF
--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -26,7 +26,7 @@ const STREAM_API_SUPPORTED =
 let streamApiShimApplied = false;
 
 export default async function(constraints, videoEl) {
-  if (STREAM_API_SUPPORTED === false) {
+  if (!STREAM_API_SUPPORTED) {
     throw new StreamApiNotSupportedError();
   }
 


### PR DESCRIPTION
StreamApiNotSupportedError is not getting thrown on Chrome in iOS because the conditional logic for the variable STREAM_API_SUPPORTED is _undefined_ and not _false_. This changes the logic to check for anything _falsey_ instead of _false_.