### PR TITLE
feat: give the binaryData of the QR code.

### DIFF
--- a/docs/api/QrcodeCapture.md
+++ b/docs/api/QrcodeCapture.md
@@ -33,7 +33,7 @@ methods: {
 ### `detect`
 * **Payload Type:** `Promise<Object>`
 
-The `detect` event is basically a verbose version of `decode`. `detect` is emitted as soon as you confirm your file selection or the foto you took with your camera. `detect` carries a Promise which resolves when scanning the images has finished. The Promise rejects in case of errors. Additionally, `detect` gives you the unprocessed raw image data and the coordinates of the QR code in the image.
+The `detect` event is basically a verbose version of `decode`. `detect` is emitted as soon as you confirm your file selection or the foto you took with your camera. `detect` carries a Promise which resolves when scanning the images has finished. The Promise rejects in case of errors. Additionally, `detect` gives you the unprocessed raw image data, the raw bytes of the QR code and the coordinates of the QR code in the image.
 
 ```html
 <qrcode-capture @detect="onDetect" />
@@ -45,6 +45,7 @@ methods: {
       const {
         imageData,    // raw image data of image/frame
         content,      // decoded String or null
+        binaryData,   // The raw bytes of the QR code
         location      // QR code coordinates or null
       } = await promise
 

--- a/docs/api/QrcodeDropZone.md
+++ b/docs/api/QrcodeDropZone.md
@@ -34,7 +34,7 @@ methods: {
 ### `detect`
 * **Payload Type:** `Promise<Object>`
 
-The `detect` event is basically a verbose version of `decode`. `detect` is emitted as soon as you drop an image. It carries a Promise which resolves when scanning the dropped image has finished. The Promise rejects in case of errors. Additionally, `detect` gives you the unprocessed raw image data and the coordinates of the QR code in the image.
+The `detect` event is basically a verbose version of `decode`. `detect` is emitted as soon as you drop an image. It carries a Promise which resolves when scanning the dropped image has finished. The Promise rejects in case of errors. Additionally, `detect` gives you the unprocessed raw image data, the raw bytes of the QR code and the coordinates of the QR code in the image.
 
 ```html
 <qrcode-drop-zone @detect="onDetect">
@@ -48,6 +48,7 @@ methods: {
       const {
         imageData,    // raw image data of image/frame
         content,      // decoded String or null
+        binaryData,   // The raw bytes of the QR code
         location      // QR code coordinates or null
       } = await promise
 

--- a/docs/api/QrcodeStream.md
+++ b/docs/api/QrcodeStream.md
@@ -44,6 +44,7 @@ The `detect` event is basically a verbose version of `decode`. `decode` only giv
 
 * is always emitted before `decode`
 * gives you the unprocessed raw image data
+* gives you the raw bytes of the QR code.
 * gives you the coordinates of the QR code in the camera frame
 * does NOT silently fail in case of errors
 
@@ -57,6 +58,7 @@ methods: {
       const {
         imageData,    // raw image data of image/frame
         content,      // decoded String
+        binaryData,   // The raw bytes of the QR code
         location      // QR code coordinates
       } = await promise
 

--- a/src/worker/jsqr.js
+++ b/src/worker/jsqr.js
@@ -22,13 +22,15 @@ export default () => {
 
       let content = null;
       let location = null;
+      let binaryData = null;
 
       if (result !== null) {
         content = result.data;
         location = result.location;
+        binaryData = result.binaryData;
       }
 
-      const message = { content, location, imageData };
+      const message = { content, location, imageData, binaryData };
       self.postMessage(message, [imageData.data.buffer]);
     });
   });


### PR DESCRIPTION
The `jsQR` library [return binary data](https://github.com/cozmo/jsQR#return-value), when QR code is able to decoded.
I added `binaryData` to the payload passed by the worker.

In my use case, I store the compressed binary data in a QR code, so I need the raw data. 