### PR TITLE
feat: Uploading from library on mobile

### DIFF
--- a/src/components/QrcodeCapture.vue
+++ b/src/components/QrcodeCapture.vue
@@ -4,7 +4,6 @@
     type="file"
     name="image"
     accept="image/*"
-    capture="environment"
     multiple
   />
 </template>


### PR DESCRIPTION
**Allow actual image uploading on mobile devices.**
The current functionality only supports capturing images in real time by clicking on the "Choose Files" Button of the `QrcodeCapture` component.
By removing the `capture` tag you can now choose between capturing an image or selecting one/multiple from your library.
Desktop behaviour stays the same.

![image](https://user-images.githubusercontent.com/33714789/95830188-9a6b0780-0d37-11eb-9a63-8741692b14ef.png)
