### PR TITLE
Fix iOS RangeError bug

### DIFF
--- a/src/worker/jsqr.js
+++ b/src/worker/jsqr.js
@@ -18,7 +18,14 @@ export default () => {
 
     self.addEventListener("message", function(event) {
       const imageData = event.data;
-      const result = jsQR(imageData.data, imageData.width, imageData.height);
+      let result = null;
+      try {
+        result = jsQR(imageData.data, imageData.width, imageData.height);
+      } catch (error) {
+        if (!(error instanceof RangeError)) {
+          throw error;
+        }
+      }
 
       let content = null;
       let location = null;


### PR DESCRIPTION
Fixes #207  on recent iOS versions where the QR Scanner stops working after about 30 seconds. This is due to an uncaught RangeError exception in jsQR.