### PR TITLE
fix: application freezes when stream is paused or stopped

### DIFF
--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -10,7 +10,12 @@ class Camera {
   }
 
   stop() {
-    this.stream.getTracks().forEach(track => track.stop());
+    this.videoEl.srcObject = null;
+
+    this.stream.getTracks().forEach(track => {
+      this.stream.removeTrack(track);
+      track.stop();
+    });
   }
 
   captureFrame() {


### PR DESCRIPTION
There is a bug with MediaStream in Chrome on Android 11 that causes the page to freeze when a MediaStream is paused or stopped. This PR is a workaround, first found by @BelkinVadim on this thread: https://github.com/twilio/twilio-video-app-react/issues/355#issuecomment-780368725.

Closes #228 

