### PR TITLE
Remove unused obsolete import

### DIFF
--- a/src/misc/scanner.js
+++ b/src/misc/scanner.js
@@ -1,4 +1,4 @@
-import { DropImageFetchError, DropImageDecodeError } from "./errors.js";
+import { DropImageFetchError } from "./errors.js";
 import { eventOn } from "callforth";
 
 const adaptOldFormat = detectedCodes => {


### PR DESCRIPTION
DropImageDecodeError was removed in https://github.com/gruhn/vue-qrcode-reader/commit/dea620ec69f0644c3c7282aff08686c8f639edbb