### PR TITLE
fix(camera): Desk View Cameras added to blacklist (de, fr, it)

### DIFF
--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -30,7 +30,7 @@ class Camera {
 // media constraints don't allow us to specify which camera we want exactly.
 const narrowDownFacingMode = async camera => {
   // Filter some devices, known to be bad choices.
-  const deviceBlackList = ["OBS Virtual Camera", "OBS-Camera", "Desk View Camera"];
+  const deviceBlackList = ["OBS Virtual Camera", "OBS-Camera", "Desk View Camera", "Schreibtischansicht-Kamera", "Caméra Desk View", "Fotocamera di Panoramica Scrivania"];
 
   const devices = (await navigator.mediaDevices.enumerateDevices())
     .filter(({ kind }) => kind === "videoinput")


### PR DESCRIPTION
The iPhone Desk View Cameras have to be added to the blacklist.
They have a different name in every language; This commit adds "de", "fr" and "it".
More info: https://support.apple.com/en-us/HT213244