### PR TITLE
fix(camera): Zoomed and Ultrawide de iPhone Camera was added into bla…

### DIFF
--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -30,7 +30,7 @@ class Camera {
 // media constraints don't allow us to specify which camera we want exactly.
 const narrowDownFacingMode = async camera => {
   // Filter some devices, known to be bad choices.
-  const deviceBlackList = ["OBS Virtual Camera", "OBS-Camera", "Desk View Camera", "Schreibtischansicht-Kamera", "Caméra Desk View", "Fotocamera di Panoramica Scrivania"];
+  const deviceBlackList = ["OBS Virtual Camera", "OBS-Camera", "Desk View Camera", "Schreibtischansicht-Kamera", "Caméra Desk View", "Fotocamera di Panoramica Scrivania", "Rückseitige Ultra-Weitwinkelkamera", "Rückseitige Telefotokamera"];
 
   const devices = (await navigator.mediaDevices.enumerateDevices())
     .filter(({ kind }) => kind === "videoinput")


### PR DESCRIPTION
Added DE iPhone zoomed and ultrawide cam to the blacklist because there is random selection between these cameras when scanning.