### PR TITLE
fix(camera): add dual/triple rear cameras to blacklist (de+en)

### DIFF
--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -30,7 +30,16 @@ class Camera {
 // media constraints don't allow us to specify which camera we want exactly.
 const narrowDownFacingMode = async camera => {
   // Filter some devices, known to be bad choices.
-  const deviceBlackList = ["OBS Virtual Camera", "OBS-Camera", "Desk View Camera", "Schreibtischansicht-Kamera", "Caméra Desk View", "Fotocamera di Panoramica Scrivania", "Rückseitige Ultra-Weitwinkelkamera", "Rückseitige Telefotokamera"];
+  const deviceBlackList = [
+    "OBS Virtual Camera",
+    "OBS-Camera",
+    "Desk View Camera",
+    "Schreibtischansicht-Kamera",
+    "Caméra Desk View",
+    "Fotocamera di Panoramica Scrivania",
+    "Rückseitige Ultra-Weitwinkelkamera",
+    "Rückseitige Telefotokamera",
+  ];
 
   const devices = (await navigator.mediaDevices.enumerateDevices())
     .filter(({ kind }) => kind === "videoinput")

--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -39,6 +39,10 @@ const narrowDownFacingMode = async camera => {
     "Fotocamera di Panoramica Scrivania",
     "Rückseitige Ultra-Weitwinkelkamera",
     "Rückseitige Telefotokamera",
+    "Rückseitige Dual-Weitwinkelkamera",
+    "Rückseitige Triple-Kamera",
+    "Back Dual Wide Camera",
+    "Back Triple Camera",
   ];
 
   const devices = (await navigator.mediaDevices.enumerateDevices())


### PR DESCRIPTION
This PR adds 4 new cameras (dual+triple, each in DE+EN) to the blacklist. It seems that those were introduced with the latest release of iOS 16.4.

I also added line breaks to the `deviceBlackList` to make future updates easier to diff.

