### PR TITLE
fix(camera): back ultra wide camera added to blacklist (en)

### DIFF
--- a/src/misc/camera.js
+++ b/src/misc/camera.js
@@ -43,6 +43,7 @@ const narrowDownFacingMode = async camera => {
     "Rückseitige Triple-Kamera",
     "Back Dual Wide Camera",
     "Back Triple Camera",
+    "Back Ultra Wide Camera",
   ];
 
   const devices = (await navigator.mediaDevices.enumerateDevices())


### PR DESCRIPTION
Fix IOS 16 bug - incorrect camera by default