### PR TITLE
fix: attempt to decode inverted QR codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "barcode-detector": "^1.0.0",
+    "barcode-detector": "^1.0.3",
     "callforth": "^0.3.1",
     "core-js": "^3.6.5",
     "vue": "^2.6.11",


### PR DESCRIPTION
Update dependency of barcode-detector to a minimum version which includes also decoding inverted QR codes. 

Related #238