### PR TITLE
feat(package): add css and src specifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       "import": "./dist/vue-qrcode-reader.js",
       "require": "./dist/vue-qrcode-reader.umd.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./dist/styles.css": {
+      "import": "./dist/style.css",
+      "require": "./dist/style.css"
     }
   },
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
       "require": "./dist/vue-qrcode-reader.umd.cjs",
       "types": "./dist/index.d.ts"
     },
-    "./dist/styles.css": {
-      "import": "./dist/style.css",
-      "require": "./dist/style.css"
-    }
+    "./style": "./dist/style.css",
+    "./src": "./src/index.ts"
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "dependencies": {
     "@sec-ant/barcode-detector": "^1.1.2",


### PR DESCRIPTION
See https://github.com/gruhn/vue-qrcode-reader/issues/360

With this PR it is possible to include styles using the shorthand

```vue
<style>
@import url('vue-qrcode-reader/style');
</style>
```

and native Vue SFCs using:

```ts
(await import('vue-qrcode-reader/src')).QrcodeStream
```