### PR TITLE
fix(QrcodeStream): styling sometimes missing

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,6 @@ pkgs.mkShell {
     nodejs_18
     nodePackages.pnpm
     nodePackages.typescript-language-server
-    nodePackages.vls
   ];
   
 }

--- a/src/misc/scanner.ts
+++ b/src/misc/scanner.ts
@@ -1,7 +1,6 @@
-import { type DetectedBarcode,  type BarcodeFormat, BarcodeDetector } from '@sec-ant/barcode-detector/pure'
+import { type DetectedBarcode, type BarcodeFormat, BarcodeDetector } from '@sec-ant/barcode-detector/pure'
 import { eventOn } from './callforth'
 import { DropImageFetchError } from './errors'
-
 
 let barcodeDetector: BarcodeDetector
 export const setScanningFormats = (formats: BarcodeFormat[]) => {


### PR DESCRIPTION
For some users the external style.css is not automatically imported. Now inline all CSS to avoid external CSS files in general.

See #360