### PR TITLE
docs(README): fix umd script link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ Vue.use(VueQrcodeReader);
 
 Include the following JS file:
 
-https://unpkg.com/vue-qrcode-reader/dist/VueQrcodeReader.umd.min.js
+https://unpkg.com/vue-qrcode-reader/dist/vue-qrcode-reader.umd.cjs
 
 Make sure to include it after Vue:
 
 ```html
 <script src="./vue.js"></script>
-<script src="./VueQrcodeReader.umd.min.js"></script>
+<script src="./vue-qrcode-reader.umd.cjs"></script>
 ```
 
 All components are automatically registered globally.


### PR DESCRIPTION
Fix #367 

Personally I think `index.umd.js` or `/umd/index.js` may be better options, as some cloud services fail to set the proper content-type for `.cjs` extensions ([ref](https://stackoverflow.com/a/76774057/4668057)). And `vue-qrcode-reader` occurs twice in the link, seems a little lengthy.

UPKG will mark `.cjs` with the content type of `text/plain`:
<details>

![image](https://github.com/gruhn/vue-qrcode-reader/assets/10386119/e291e02c-e54b-457c-8ba2-d8f809dc817e)
</details>

jsDelivr will mark it with `application/node`:
<details>

![image](https://github.com/gruhn/vue-qrcode-reader/assets/10386119/836c31c9-4eda-40ce-99fb-0bb25ea71045)
</details>