### PR TITLE
docs(QrcodeCapture): Valid values for the force file dialog

### DIFF
--- a/docs/.vitepress/components/demos/Upload.vue
+++ b/docs/.vitepress/components/demos/Upload.vue
@@ -29,7 +29,7 @@ export default {
     const options = [
       { text: 'rear camera (default)', value: 'environment' },
       { text: 'front camera', value: 'user' },
-      { text: 'force file dialog', value: false }
+      { text: 'force file dialog', value: null }
     ]
 
     return {


### PR DESCRIPTION
When set to `false`, it still evokes the camera. (An invalid value of `false` will be falls back to the implementation-specific default facing mode.)
Removing the `capture` attribute by setting it to `null` forces the file dialog correctly.