### PR TITLE
chore: switch to barcode-detector@2.0.1

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   env: {
     node: true,
-    es2022: true,
+    es2022: true
   },
   extends: [
     'plugin:vue/vue3-essential',
@@ -10,6 +10,7 @@ module.exports = {
     '@vue/eslint-config-typescript',
     '@vue/eslint-config-prettier/skip-formatting'
   ],
+  ignore: ['dist'],
   parserOptions: {
     ecmaVersion: 11
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dist"
   ],
   "dependencies": {
-    "@sec-ant/barcode-detector": "^1.2.2",
+    "barcode-detector": "^2.0.1",
     "webrtc-adapter": "^8.2.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
-  '@sec-ant/barcode-detector':
-    specifier: ^1.2.2
-    version: 1.2.2(react@18.2.0)
+  barcode-detector:
+    specifier: ^2.0.1
+    version: 2.0.1(react@18.2.0)
   webrtc-adapter:
     specifier: ^8.2.3
     version: 8.2.3
@@ -2055,19 +2059,8 @@ packages:
       string-argv: 0.3.2
     dev: true
 
-  /@sec-ant/barcode-detector@1.2.2(react@18.2.0):
-    resolution: {integrity: sha512-S/lBVP0kgr6+sGorOKup0NNB4wLB3ZbmYjSx+D7eEZbPf8qc95Y6SRu/Xg55oyqJGAGPSttgMyVqKKEltC253Q==}
-    dependencies:
-      '@sec-ant/zxing-wasm': 2.1.3(react@18.2.0)
-      '@types/dom-webcodecs': 0.1.8
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-    dev: false
-
-  /@sec-ant/zxing-wasm@2.1.3(react@18.2.0):
-    resolution: {integrity: sha512-Tna0mlSSzEBD6mEvJpnHncxm97LK6NaXCzHJAlw38GX3BRpNJ0xJe0WvS76udvUd7rF+Cwgl6x/U7Sn1/Ue0qg==}
+  /@sec-ant/zxing-wasm@2.1.4(react@18.2.0):
+    resolution: {integrity: sha512-7KmKMvN5nT4AL5hrXzTouO6MBSK4mZladSaiYT7gDqEMRiHcEKBfrgV3f0KwWeUSexzouQMJrczYvobXtXl3Ig==}
     dependencies:
       '@types/emscripten': 1.39.7
       zustand: 4.4.1(react@18.2.0)
@@ -2860,6 +2853,17 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
+
+  /barcode-detector@2.0.1(react@18.2.0):
+    resolution: {integrity: sha512-B7brBlxLRFyBjf8jVBxVHzRSN7bo0DteZbw27rzPYAS8SDMjTYj8kCijTCInS/Ru5wi700ntOtbLnOrVJyZNaw==}
+    dependencies:
+      '@sec-ant/zxing-wasm': 2.1.4(react@18.2.0)
+      '@types/dom-webcodecs': 0.1.8
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+    dev: false
 
   /before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
@@ -6980,7 +6984,3 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/src/components/QrcodeCapture.vue
+++ b/src/components/QrcodeCapture.vue
@@ -12,7 +12,7 @@
 <script setup lang="ts">
 import { type PropType } from 'vue'
 import { processFile } from '../misc/scanner'
-import { type BarcodeFormat } from '@sec-ant/barcode-detector/pure'
+import { type BarcodeFormat } from 'barcode-detector/pure'
 
 const props = defineProps({
   formats: {

--- a/src/components/QrcodeDropZone.vue
+++ b/src/components/QrcodeDropZone.vue
@@ -12,7 +12,7 @@
 <script setup lang="ts">
 import { type PropType } from 'vue'
 import { processFile, processUrl } from '../misc/scanner'
-import { type BarcodeFormat } from '@sec-ant/barcode-detector/pure'
+import { type BarcodeFormat } from 'barcode-detector/pure'
 
 const props = defineProps({
   formats: {

--- a/src/components/QrcodeStream.vue
+++ b/src/components/QrcodeStream.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import type { DetectedBarcode, BarcodeFormat } from '@sec-ant/barcode-detector/pure'
+import type { DetectedBarcode, BarcodeFormat } from 'barcode-detector/pure'
 import { onUnmounted, computed, onMounted, ref, toRefs, watch, type PropType, type CSSProperties } from 'vue'
 
 import { keepScanning, setScanningFormats } from '../misc/scanner'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import QrcodeStream from './components/QrcodeStream.vue'
 import QrcodeCapture from './components/QrcodeCapture.vue'
 import QrcodeDropZone from './components/QrcodeDropZone.vue'
 
-import { setZXingModuleOverrides } from '@sec-ant/barcode-detector/pure'
+import { setZXingModuleOverrides } from 'barcode-detector/pure'
 
 // Install the components
 export function install(app: App) {

--- a/src/misc/scanner.ts
+++ b/src/misc/scanner.ts
@@ -1,4 +1,4 @@
-import { type DetectedBarcode, type BarcodeFormat, BarcodeDetector } from '@sec-ant/barcode-detector/pure'
+import { type DetectedBarcode, type BarcodeFormat, BarcodeDetector } from 'barcode-detector/pure'
 import { eventOn } from './callforth'
 import { DropImageFetchError } from './errors'
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,18 @@ export default defineConfig({
     }
   },
   build: {
+    // these are the targets supported by zxing webassembly
+    // ----------------------------------------------------
+    // according to: https://esbuild.github.io/api/#target
+    // esbuild will transpile newer ES syntaxes according to this list
+    // newer web APIs will still have to be polyfilled if they don't exist
+    // ----------------------------------------------------
+    // according to: https://github.com/emscripten-core/emscripten/blob/b72550132f8381c3f3021853505159f6f6b11e48/src/settings.js#L1763-L1812
+    // even older browsers may still be supported, however let's settle on this until someone complains
+    // ----------------------------------------------------
+    // safari 13 support is requested by: https://github.com/Sec-ant/barcode-detector/issues/11
+    // others are defaults from emscripten and vite
+    target: ['es2020', 'edge88', 'firefox68', 'chrome75', 'safari13'],
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'VueQrcodeReader'


### PR DESCRIPTION
- `@sec-ant/barcode-detector` package name changed to `barcode-detector`
- `barcode-detector@2.0.1` supports iOS/Safari 13.0
  This was requested by https://github.com/Sec-ant/barcode-detector/issues/11 .
  The new version also attempts to address #368 without introducing a polyfill for `createImageBitmap`.