### PR TITLE
docs: camera picker for torch demo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
     '@vue/eslint-config-typescript',
     '@vue/eslint-config-prettier/skip-formatting'
   ],
-  ignore: ['dist'],
+  ignorePatterns: ['dist/'],
   parserOptions: {
     ecmaVersion: 11
   }

--- a/docs/.vitepress/components/demos/Torch.vue
+++ b/docs/.vitepress/components/demos/Torch.vue
@@ -1,8 +1,23 @@
 <template>
   <div>
+    <p>
+      Pick camera:
+      <select v-model="selected">
+        <option v-for="device in devices" :key="device.label" :value="device">
+          {{ device.label }}
+        </option>
+      </select>
+    </p>
+
     <p v-if="torchNotSupported" class="error">Torch not supported for active camera</p>
 
-    <qrcode-stream :torch="torchActive" @camera-on="onCameraOn" @error="onError">
+    <qrcode-stream 
+      :torch="torchActive" 
+      :constraints="{ deviceId: selected.deviceId }" 
+      v-if="selected !== null"       
+      @error="console.error"
+      @camera-on="onCameraOn" 
+    >
       <button @click="torchActive = !torchActive" :disabled="torchNotSupported">
         <img :src="withBase(icon)" alt="toggle torch" />
       </button>
@@ -10,38 +25,41 @@
   </div>
 </template>
 
-<script>
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
 import { withBase } from 'vitepress'
-
 import { QrcodeStream } from '../../../../src'
 
-export default {
-  components: { QrcodeStream },
+const selected = ref(null)
+const devices = ref([])
 
-  data() {
-    return {
-      torchActive: false,
-      torchNotSupported: false
-    }
-  },
+onMounted(async () => {
+  devices.value = (await navigator.mediaDevices.enumerateDevices())
+    .filter(({ kind }) => kind === 'videoinput')
 
-  computed: {
-    icon() {
-      if (this.torchActive) return '/flash-off.svg'
-      else return '/flash-on.svg'
-    }
-  },
+	if (devices.value.length > 0) {
+		selected.value = devices.value[0]	
+	}
+})
 
-  methods: {
-    onCameraOn(capabilities) {
-      console.log(capabilities)
-      this.torchNotSupported = !capabilities.torch
-    },
+const torchActive = ref(false)
+const torchNotSupported = ref(false)
 
-    onError: console.error,
-
-    withBase
+const icon = computed(() => {
+  if (torchActive.value) { 
+    return '/flash-off.svg'
+  } else { 
+    return '/flash-on.svg'
   }
+})
+
+function onCameraOn(capabilities) {
+  console.log(capabilities)
+  torchNotSupported.value = !capabilities.torch
+}
+
+function onError(err) { 
+  console.error(err)
 }
 </script>
 


### PR DESCRIPTION
Add camera picker to Torch demo, so users can select a different camera, if the default choice does not support torch.

See: #380