### PR TITLE
refactor(camera.ts): task queue

### DIFF
--- a/src/components/QrcodeStream.vue
+++ b/src/components/QrcodeStream.vue
@@ -118,7 +118,7 @@ watch(cameraSettings, async cameraSettings => {
       // ... thus we check whether the component is still alive right after the promise resolves and stop 
       // the camera otherwise.
       if (!isMounted.value) {
-        cameraController.stop()
+        await cameraController.stop()
       } else {
         cameraActive.value = true
         emit('camera-on', capabilities)


### PR DESCRIPTION
Implement a task queue to keep camera start and stop tasks in order and mitigate potential race conditions.

Users will notice some delay when they open and close the camera frequently (e.g. switching cameras quickly, turning on and off the torch quickly, etc.) because each start and stop action is saved in the task queue and dequeues in order, with no abortion.

Abortion can be added if this is a matter of concern.