### PR TITLE
feat：support formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "barcode-detector": "^1.0.3",
+    "barcode-detector": "2.2.2",
     "callforth": "^0.3.1",
     "core-js": "^3.6.5",
     "vue": "^2.6.11",

--- a/src/components/QrcodeCapture.vue
+++ b/src/components/QrcodeCapture.vue
@@ -16,12 +16,19 @@ import CommonAPI from "../mixins/CommonAPI.vue";
 export default {
   name: "qrcode-capture",
 
+  props:{
+    formats: {
+      type: Array,
+      default: () => ["qr_code"]
+    }
+  },
+
   mixins: [CommonAPI],
 
   methods: {
     onChangeInput(event) {
       const files = [...event.target.files];
-      const resultPromises = files.map(processFile);
+      const resultPromises = files.map(file => processFile(file, this.formats));
 
       resultPromises.forEach(this.onDetect);
     }

--- a/src/components/QrcodeDropZone.vue
+++ b/src/components/QrcodeDropZone.vue
@@ -16,6 +16,12 @@ import CommonAPI from "../mixins/CommonAPI.vue";
 export default {
   name: "qrcode-drop-zone",
 
+  props:{
+    formats: {
+      type: Array,
+      default: () => ["qr_code"]
+    }
+  },
   mixins: [CommonAPI],
 
   methods: {
@@ -30,11 +36,11 @@ export default {
       const droppedUrl = dataTransfer.getData("text/uri-list");
 
       droppedFiles.forEach(file => {
-        this.onDetect(processFile(file));
+        this.onDetect(processFile(file, this.formats));
       });
 
       if (droppedUrl !== "") {
-        this.onDetect(processUrl(droppedUrl));
+        this.onDetect(processUrl(droppedUrl, this.formats));
       }
     }
   }

--- a/src/components/QrcodeStream.vue
+++ b/src/components/QrcodeStream.vue
@@ -55,6 +55,11 @@ export default {
 
     track: {
       type: Function
+    },
+
+    formats: {
+      type: Array,
+      default: () => ["qr_code"]
     }
   },
 
@@ -170,7 +175,8 @@ export default {
       keepScanning(this.$refs.video, {
         detectHandler,
         locateHandler: this.onLocate,
-        minDelay: this.scanInterval
+        minDelay: this.scanInterval,
+        formats: this.formats
       });
     },
 

--- a/src/misc/scanner.js
+++ b/src/misc/scanner.js
@@ -1,3 +1,4 @@
+import {  BarcodeDetector } from 'barcode-detector'
 import { DropImageFetchError } from "./errors.js";
 import { eventOn } from "callforth";
 
@@ -41,9 +42,9 @@ const adaptOldFormat = detectedCodes => {
  * potentially pictured QR codes.
  */
 export const keepScanning = (videoElement, options) => {
-  const barcodeDetector = new BarcodeDetector({ formats: ["qr_code"] });
+  const { detectHandler, locateHandler, minDelay, formats } = options;
 
-  const { detectHandler, locateHandler, minDelay } = options;
+  const barcodeDetector = new BarcodeDetector({ formats });
 
   const processFrame = state => async timeNow => {
     if (videoElement.readyState > 1) {
@@ -92,15 +93,15 @@ const imageElementFromUrl = async url => {
   return image;
 }
 
-export const processFile = async file => {
-  const barcodeDetector = new BarcodeDetector({ formats: ["qr_code"] })
+export const processFile = async (file, formats) => {
+  const barcodeDetector = new BarcodeDetector({ formats })
   const detectedCodes = await barcodeDetector.detect(file)
 
   return adaptOldFormat(detectedCodes)
 }
 
-export const processUrl = async url => {
-  const barcodeDetector = new BarcodeDetector({ formats: ["qr_code"] })
+export const processUrl = async (url, formats) => {
+  const barcodeDetector = new BarcodeDetector({ formats })
   const image = await imageElementFromUrl(url);
   const detectedCodes = await barcodeDetector.detect(image)
 


### PR DESCRIPTION
vue-qrcode-reader^3.x version Support barcode formats other than QR codes
1. Upgrade barcode detector dependency from 1.0.3 to 2.2.2 to provide support for barcode formats other than QR codes