### PR TITLE
fix(FullDemo): hidden device ID dropdown

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,11 +1,10 @@
 import { defineConfig } from 'vitepress'
 import { withPwa } from '@vite-pwa/vitepress'
 
-const { VITEPRESS_BASE } = process.env
-
-if (VITEPRESS_BASE === undefined) {
-  throw new Error('env var VITEPRESS_BASE is undefined')
+if (process.env.VITEPRESS_BASE === undefined) {
+  console.warn('env var VITEPRESS_BASE is undefined. Defaulting to: /vue-qrcode-reader/')
 }
+const { VITEPRESS_BASE } = process.env ?? '/vue-qrcode-reader/'
 
 export default withPwa(
   defineConfig({
@@ -69,7 +68,7 @@ export default withPwa(
           {
             text: 'Decode by Upload',
             link: '/demos/Upload'
-          },
+          }
         ],
         '/api/': [
           {

--- a/src/misc/camera.ts
+++ b/src/misc/camera.ts
@@ -29,6 +29,11 @@ async function runStartTask(
   constraints: MediaTrackConstraints,
   torch: boolean
 ): Promise<StartTaskResult> {
+  console.debug(
+    '[vue-qrcode-reader] starting camera with constraints: ',
+    JSON.stringify(constraints)
+  )
+
   // At least in Chrome `navigator.mediaDevices` is undefined when the page is
   // loaded using HTTP rather than HTTPS. Thus `STREAM_API_NOT_SUPPORTED` is
   // initialized with `false` although the API might actually be supported.
@@ -47,6 +52,7 @@ async function runStartTask(
   // is not available during SSR. So we lazily apply this shim at runtime.
   shimGetUserMedia()
 
+  console.debug('[vue-qrcode-reader] calling getUserMedia')
   const stream = await navigator.mediaDevices.getUserMedia({
     audio: false,
     video: constraints
@@ -69,6 +75,7 @@ async function runStartTask(
   // unless video is explictly triggered by play()
   videoEl.play()
 
+  console.debug('[vue-qrcode-reader] waiting for video element to load')
   await Promise.race([
     eventOn(videoEl, 'loadeddata'),
 
@@ -82,6 +89,7 @@ async function runStartTask(
       throw new StreamLoadTimeoutError()
     })
   ])
+  console.debug('[vue-qrcode-reader] video element loaded')
 
   // According to: https://oberhofer.co/mediastreamtrack-and-its-capabilities/#queryingcapabilities
   // On some devices, getCapabilities only returns a non-empty object after
@@ -98,6 +106,7 @@ async function runStartTask(
     isTorchOn = true
   }
 
+  console.debug('[vue-qrcode-reader] camera ready')
   return {
     type: 'start',
     data: {
@@ -174,6 +183,8 @@ async function runStopTask(
   stream: MediaStream,
   isTorchOn: boolean
 ): Promise<StopTaskResult> {
+  console.debug('[vue-qrcode-reader] stopping camera')
+
   videoEl.src = ''
   videoEl.srcObject = null
   videoEl.load()

--- a/src/misc/scanner.ts
+++ b/src/misc/scanner.ts
@@ -27,12 +27,15 @@ export const keepScanning = async (
     formats: BarcodeFormat[]
   }
 ) => {
+  console.debug('[vue-qrcode-reader] start scanning')
   barcodeDetector = new BarcodeDetector({ formats })
 
   const processFrame =
     (state: { lastScanned: number; contentBefore: string[]; lastScanHadContent: boolean }) =>
     async (timeNow: number) => {
-      if (videoElement.readyState > 1) {
+      if (videoElement.readyState === 0) {
+        console.debug('[vue-qrcode-reader] stop scanning: video element readyState is 0')
+      } else {
         const { lastScanned, contentBefore, lastScanHadContent } = state
 
         // Scanning is expensive and we don't need to scan camera frames with


### PR DESCRIPTION
When listing available cameras with `enumerateDevices` the `label` field is an empty string in some browsers. In that case, the dropdown to select a camera on the "full demo" is invisible because all selectable options are empty strings. Fixing that by also including the device ID (not just the label) so some text is always rendered.

Also added logging statements for all kinds of state transitions.