### PR TITLE
fix: native `BarocdeDetector` doesn't support requested formats

### DIFF
--- a/docs/api/QrcodeStream.md
+++ b/docs/api/QrcodeStream.md
@@ -98,11 +98,29 @@ However changing the value of `paused` resets this internal cache.
 - **Default:** `['qr_code']`
 
 The `formats` prop defines which barcode formats are detected.
-[Supported Formats](https://github.com/Sec-ant/barcode-detector?tab=readme-ov-file#barcode-detector).
+By default, only QR codes are selected, 
+so if you want to scan other barcode formats, 
+you have to modify this prop.
+See: [supported formats](https://github.com/Sec-ant/barcode-detector?tab=readme-ov-file#barcode-detector).
 
 ```html
 <qrcode-stream :formats="['qr_code', 'code_128']"></qrcode-stream>
 ```
+
+::: warning
+Don't select more barcode formats than needed. 
+Scanning becomes more expensive the more formats you select.
+:::
+
+Under the hood, we use the standard 
+[`BarcodeDetector`](https://developer.mozilla.org/en-US/docs/Web/API/BarcodeDetector) 
+browser API.
+Support varies across devices, operating systems and browsers.
+The component will prefer to use the native implementation if available and otherwise falls back to a polyfill implementation.
+Note that even if the native implementation is availabe,  
+the component still might use the polyfill.
+For example, if the native implementation only supports the 
+format `'qr_come'` but the you select the formats `['qr_code', 'aztec']`.
 
 ### `camera-on` <Badge text="since v5.0.0" type="info" />
 

--- a/docs/api/QrcodeStream.md
+++ b/docs/api/QrcodeStream.md
@@ -120,7 +120,7 @@ The component will prefer to use the native implementation if available and othe
 Note that even if the native implementation is availabe,  
 the component still might use the polyfill.
 For example, if the native implementation only supports the 
-format `'qr_come'` but the you select the formats `['qr_code', 'aztec']`.
+format `'qr_code'` but the you select the formats `['qr_code', 'aztec']`.
 
 ### `camera-on` <Badge text="since v5.0.0" type="info" />
 

--- a/src/components/QrcodeStream.vue
+++ b/src/components/QrcodeStream.vue
@@ -231,10 +231,10 @@ watch(
   { deep: true }
 )
 
-// Set formats will create a new BarcodeDetector instance with the given formats.
-watch(formatsCached, (formats) => {
+// `setScanningFormats` will create a new BarcodeDetector instance with the given formats.
+watch(formatsCached, async formats => {
   if (isMounted.value) {
-    setScanningFormats(formats)
+    await setScanningFormats(formats)
   }
 })
 

--- a/src/misc/scanner.ts
+++ b/src/misc/scanner.ts
@@ -23,7 +23,7 @@ let barcodeDetector: BarcodeDetector
 /**
  * Constructs a `BarcodeDetector` instance, given a list of targeted barcode formats.
  * Preferably, we want to use the native `BarcodeDetector` implementation if supported. 
- * Otherwise, we fallback to the polyfill implementation.
+ * Otherwise, we fall back to the polyfill implementation.
  *
  * Note, that we can't just monkey patch the polyfill on load, i.e. 
  *


### PR DESCRIPTION
Previously we always used the native `BarocdeDetector` implementation if available. However, the native API might be available but does not support the barcode formats requested by the user. For example, `"qr_code"` might be supported but the user wants to scan `["qr_code", "aztec"]`. In these cases, we now also fallback to the polyfill implementation.

Closes #450