### PR TITLE
fix: #429

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,9 @@
     {
       "path": "./tsconfig.app.json"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "module": "ES2020",
+    "moduleResolution": "Bundler"
+  }
 }


### PR DESCRIPTION
Referring to [vite-plugin-dts#227](https://github.com/qmhc/vite-plugin-dts/issues/277), I found that since #429 was caused by the `moduleResolution` option not being included in `tsconfig.json` , this PR fixes the problem