### PR TITLE
fix: PDF471 codes on desktop Mac

### DIFF
--- a/src/misc/scanner.ts
+++ b/src/misc/scanner.ts
@@ -1,6 +1,7 @@
 import { type DetectedBarcode, type BarcodeFormat, BarcodeDetector, type BarcodeDetectorOptions } from 'barcode-detector/pure'
 import { eventOn } from './callforth'
 import { DropImageFetchError } from './errors'
+import { isMac } from './util'
 
 declare global {
   interface Window { 
@@ -48,6 +49,12 @@ async function createBarcodeDetector(formats: BarcodeFormat[]): Promise<BarcodeD
     return new BarcodeDetector({ formats })
   }
 
+  if (isMac() && formats.includes('pdf417')) {
+    // See: #459
+    console.debug(`[vue-qrcode-reader] Native BarcodeDetector is buggy for PDF417 codes on MacOS. Will use polyfill.`)
+    return new BarcodeDetector({ formats })
+  }
+  
   console.debug('[vue-qrcode-reader] Will use native BarcodeDetector.')
   return new window.BarcodeDetector({ formats })
 }

--- a/src/misc/util.ts
+++ b/src/misc/util.ts
@@ -49,3 +49,10 @@ export function assert(condition: boolean, failureMessage?: string): asserts con
 export function assertNever(_witness: never): never {
   throw new Error('this code should be unreachable')
 }
+
+/**
+ * Returns true iff the users operating system is desktop MacOS.
+ */
+export function isMac(): boolean {
+  return navigator.platform.toUpperCase().includes('MAC')
+}


### PR DESCRIPTION
The native BarcodeDetector implementation on desktop Mac seems to support PDF417 codes but when scanning (always?) returns an empty string. Thus, now falling back to polyfill under these conditions.

See: #459