### PR TITLE
Fix type of constraints in QrcodeStream

### DIFF
--- a/src/components/QrcodeStream.vue
+++ b/src/components/QrcodeStream.vue
@@ -91,7 +91,7 @@ export interface QrcodeStreamProps {
 
 const props = withDefaults(defineProps<QrcodeStreamProps>(), {
   // in this file: don't use `props.constraints` directly. Use `constraintsCached`.
-  constraints: () => ({ facingMode: 'environment' }),
+  constraints: () => ({ facingMode: 'environment' } as MediaTrackConstraints),
   // in this file: don't use `props.formats` directly. Use `formatsCached`.
   formats: () => ['qr_code'],
   paused: false,


### PR DESCRIPTION
This fixes a small issue with the exported type for `QrcodeStream` - that originated in cc200c46fcce1ccbc1e9176fcf303ad56859d025 (My app works and build with v5.6.0, but does not build with v5.7.0).  When building my app, I got the following typescript error.
```
src/components/CodeScanner.vue:138:8 - error TS2322: Type '{ deviceId?: string | undefined; facingMode?: string | undefined; }' is not assignable to type '{ facingMode: string; }'.
  Types of property 'facingMode' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

138       :constraints="selectedConstraints"
           ~~~~~~~~~~~
  node_modules/vue-qrcode-reader/dist/components/QrcodeStream.vue.d.ts:66:5
    66     constraints: {
           ~~~~~~~~~~~
    The expected type comes from property 'constraints' which is declared here on type 'Partial<{ formats: ("unknown" | "aztec" | "code_128" | "code_39" | "code_93" | "codabar" | "databar" | "databar_expanded" | "data_matrix" | "dx_film_edge" | "ean_13" | "ean_8" | "itf" | ... 8 more ... | "matrix_codes")[]; track: (detectedCodes: DetectedBarcode[], ctx: CanvasRenderingContext2D) => void; torch: boolea...'
```

By declaring the default constraint as `MediaTrackContraints` the outputted type changes like this:
```diff
declare const __VLS_component: import("vue").DefineComponent<__VLS_WithDefaults<__VLS_TypePropsToRuntimeProps<QrcodeStreamProps>, {
-    constraints: () => {
-        facingMode: string;
-    };
+    constraints: () => MediaTrackConstraints;
     formats: () => string[];
     paused: boolean;
     torch: boolean;
     track: any;
 }>, {}, unknown, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {
     detect: (detectedCodes: DetectedBarcode[]) => void;
     "camera-on": (capabilities: Partial<MediaTrackCapabilities>) => void;
     "camera-off": () => void;
     error: (error: EmittedError) => void;
 }, string, import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps, Readonly<import("vue").ExtractPropTypes<__VLS_WithDefaults<__VLS_TypePropsToRuntimeProps<QrcodeStreamProps>, {
-    constraints: () => {
-        facingMode: string;
-    };
+    constraints: () => MediaTrackConstraints;
     formats: () => string[];
     paused: boolean;
     torch: boolean;
     track: any;
 }>>> & {
     onError?: (error: EmittedError) => any;
     onDetect?: (detectedCodes: DetectedBarcode[]) => any;
     "onCamera-on"?: (capabilities: Partial<MediaTrackCapabilities>) => any;
     "onCamera-off"?: () => any;
 }, {
     formats: BarcodeFormat[];
     track: (detectedCodes: DetectedBarcode[], ctx: CanvasRenderingContext2D) => void;
     torch: boolean;
-    constraints: {
-        facingMode: string;
-    };
+    constraints: MediaTrackConstraints;
     paused: boolean;
 }, {}>;
```